### PR TITLE
Remove unnecessary debug print

### DIFF
--- a/clean_path.py
+++ b/clean_path.py
@@ -80,7 +80,6 @@ class ChainPaths(inkex.Effect):
           type='float', dest='chain_epsilon', default=0.01, help="Max. distance to connect [mm]")
 
   def version(self):
-    print "hiuhu"
     return __version__
   def author(self):
     return __author__


### PR DESCRIPTION
This caused an error message on systems using Python 3

BTW: Thanks for the extension, it works great for me!